### PR TITLE
feat: add get_uri

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
         run: scarb build
 
       - name: Run scarb tests
-        run: scarb test -p naming
+        run: scarb test -p custom_uri

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: CI Tests
+
+on: [push, pull_request, pull_request_target]
+
+env:
+  SCARB_VERSION: 2.3.0-rc1
+
+jobs:
+  scarb-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install scarb
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh -s -- -v $SCARB_VERSION
+
+      - name: Install project dependencies
+        run: scarb fetch
+
+      - name: Compile smart contracts
+        run: scarb build
+
+      - name: Run scarb tests
+        run: scarb test -p naming

--- a/src/interface.cairo
+++ b/src/interface.cairo
@@ -1,7 +1,6 @@
 #[starknet::interface]
 trait IInternalCustomURI<TComponentState> {
     fn get_base_uri(self: @TComponentState) -> Array<felt252>;
-    fn get_uri(self: @TComponentState, value: u128) -> Array<felt252>;
-    fn get_uri_u256(self: @TComponentState, value: u256) -> Array<felt252>;
+    fn get_uri(self: @TComponentState, value: u256) -> Array<felt252>;
     fn set_base_uri(ref self: TComponentState, base_uri: Span<felt252>);
 }

--- a/src/main.cairo
+++ b/src/main.cairo
@@ -1,9 +1,14 @@
 #[starknet::component]
 mod custom_uri_component {
+    use core::traits::AddEq;
+    use core::option::OptionTrait;
+    use core::traits::TryInto;
     use core::array::ArrayTrait;
     use starknet::ContractAddress;
     use starknet::get_caller_address;
     use custom_uri::interface::IInternalCustomURI;
+    use super::{append_to_str, div_rec};
+    use debug::PrintTrait;
 
     #[storage]
     struct Storage {
@@ -17,22 +22,134 @@ mod custom_uri_component {
 
     impl InternalImpl<T, +HasComponent<T>> of IInternalCustomURI<ComponentState<T>> {
         fn get_base_uri(self: @ComponentState<T>) -> Array<felt252> {
-            Default::default()
+            let mut output = ArrayTrait::new();
+            let mut i = 0;
+            loop {
+                let value = self.uri.read(i);
+                if value == 0 {
+                    break;
+                };
+                output.append(value);
+                i += 1;
+            };
+            output
         }
 
-        fn get_uri(self: @ComponentState<T>, value: u128) -> Array<felt252> {
-            Default::default()
-        }
+        fn get_uri(self: @ComponentState<T>, mut value: u256) -> Array<felt252> {
+            let mut base = self.get_base_uri();
+            let ten: NonZero<u256> = 10_u256.try_into().unwrap();
+            let to_add = div_rec(value, ten);
 
-        fn get_uri_u256(self: @ComponentState<T>, value: u256) -> Array<felt252> {
-            Default::default()
+            let mut output = ArrayTrait::new();
+            let mut last_i = base.len() - 1;
+            let last = *base.at(last_i);
+            let mut i = 0;
+            loop {
+                if i == last_i {
+                    break;
+                }
+                output.append(*base.at(i));
+                i += 1;
+            };
+            append_to_str(ref output, last.into(), to_add.span());
+            output
         }
 
         fn set_base_uri(ref self: ComponentState<T>, mut base_uri: Span<felt252>) {
-            match base_uri.pop_front() {
-                Option::Some(value) => {},
-                Option::None => {}
-            }
+            // writing end of text
+            self.uri.write(base_uri.len().into(), 0);
+            loop {
+                match base_uri.pop_back() {
+                    Option::Some(value) => { self.uri.write(base_uri.len().into(), *value); },
+                    Option::None => { break; }
+                }
+            };
         }
     }
+}
+
+fn div_rec(value: u256, divider: NonZero<u256>) -> Array<felt252> {
+    let (value, digit) = DivRem::div_rem(value, divider);
+    let mut output = if value == 0 {
+        Default::default()
+    } else {
+        div_rec(value, divider)
+    };
+    output.append(48 + digit.try_into().unwrap());
+    output
+}
+
+fn append_to_str(ref str: Array<felt252>, last_field: u256, to_add: Span<felt252>) {
+    let mut free_space: usize = 0;
+    let ascii_length: NonZero<u256> = 256_u256.try_into().unwrap();
+    let mut i = 0;
+    let mut shifted_field = last_field;
+    loop {
+        let (_shifted_field, char) = DivRem::div_rem(shifted_field, ascii_length);
+        shifted_field = _shifted_field;
+        if char == 0 {
+            free_space += 1;
+        } else {
+            free_space = 0;
+        };
+        i += 1;
+        if i == 31 {
+            break;
+        }
+    };
+
+    let mut new_field = 0;
+    let mut shift = 1;
+    let mut i = free_space;
+
+    loop {
+        if free_space == 0 {
+            break;
+        }
+        free_space -= 1;
+        match to_add.get(free_space) {
+            Option::Some(c) => {
+                new_field += shift * *c.unbox();
+                shift *= 256;
+            },
+            Option::None => {}
+        };
+    };
+    new_field += last_field.try_into().expect('invalid string') * shift;
+    str.append(new_field);
+    if i >= to_add.len() {
+        return;
+    }
+
+    let mut new_field_shift = 1;
+    let mut new_field = 0;
+    let mut j = i + 30;
+
+    loop {
+        match to_add.get(j) {
+            Option::Some(char) => {
+                new_field += new_field_shift * *char.unbox();
+                if new_field_shift == 0x100000000000000000000000000000000000000000000000000000000000000 {
+                    str.append(new_field);
+                    new_field_shift = 1;
+                    new_field = 0;
+                } else {
+                    new_field_shift *= 256;
+                }
+            },
+            Option::None => {},
+        }
+        if j == i {
+            i += 31;
+            j = i + 30;
+            str.append(new_field);
+            if i >= to_add.len() {
+                break;
+            }
+            new_field_shift = 1;
+            new_field = 0;
+        } else {
+            j -= 1;
+        };
+    };
 }

--- a/src/main.cairo
+++ b/src/main.cairo
@@ -8,7 +8,6 @@ mod custom_uri_component {
     use starknet::get_caller_address;
     use custom_uri::interface::IInternalCustomURI;
     use super::{append_to_str, div_rec};
-    use debug::PrintTrait;
 
     #[storage]
     struct Storage {

--- a/src/main.cairo
+++ b/src/main.cairo
@@ -83,6 +83,7 @@ fn append_to_str(ref str: Array<felt252>, last_field: u256, to_add: Span<felt252
     let ascii_length: NonZero<u256> = 256_u256.try_into().unwrap();
     let mut i = 0;
     let mut shifted_field = last_field;
+    // find free space in last text field
     loop {
         let (_shifted_field, char) = DivRem::div_rem(shifted_field, ascii_length);
         shifted_field = _shifted_field;
@@ -100,7 +101,7 @@ fn append_to_str(ref str: Array<felt252>, last_field: u256, to_add: Span<felt252
     let mut new_field = 0;
     let mut shift = 1;
     let mut i = free_space;
-
+    // add digits to the last text field
     loop {
         if free_space == 0 {
             break;
@@ -123,7 +124,7 @@ fn append_to_str(ref str: Array<felt252>, last_field: u256, to_add: Span<felt252
     let mut new_field_shift = 1;
     let mut new_field = 0;
     let mut j = i + 30;
-
+    // keep adding digits by chunks of 31
     loop {
         match to_add.get(j) {
             Option::Some(char) => {

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -44,7 +44,7 @@ fn test_base_uri() {
     let read_base_uri = uri_component.get_base_uri();
     assert(base_uri == read_base_uri, 'unexpected base_uri 1');
 
-    // make sure the 0 is written at the end
+    // test uri of 31 chars
     let base_uri = array!['https://api.starknet.id/uri?id='];
     uri_component.set_base_uri(base_uri.span());
     let read_base_uri = uri_component.get_base_uri();

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -1,8 +1,6 @@
 use custom_uri::main::custom_uri_component::{InternalImpl, component_state_for_testing};
 use custom_uri::main::custom_uri_component;
 use custom_uri::main::append_to_str;
-use debug::PrintTrait;
-
 
 #[starknet::contract]
 mod DummyContract {

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -1,5 +1,8 @@
 use custom_uri::main::custom_uri_component::{InternalImpl, component_state_for_testing};
 use custom_uri::main::custom_uri_component;
+use custom_uri::main::append_to_str;
+use debug::PrintTrait;
+
 
 #[starknet::contract]
 mod DummyContract {
@@ -34,9 +37,168 @@ impl TestingStateDefault of Default<TestingState> {
 }
 
 #[test]
-#[available_gas(200000)]
-fn test_ownable_initializer() {
+#[available_gas(2000000)]
+fn test_base_uri() {
     let mut uri_component: TestingState = Default::default();
+
+    let base_uri = array!['a', 'b', 'c'];
+    uri_component.set_base_uri(base_uri.span());
+    let read_base_uri = uri_component.get_base_uri();
+    assert(base_uri == read_base_uri, 'unexpected base_uri 1');
+
+    // make sure the 0 is written at the end
     let base_uri = array!['https://api.starknet.id/uri?id='];
     uri_component.set_base_uri(base_uri.span());
+    let read_base_uri = uri_component.get_base_uri();
+    assert(base_uri == read_base_uri, 'unexpected base_uri 2');
+}
+
+
+#[test]
+#[available_gas(40000000)]
+fn test_appending_id() {
+    let mut uri_component: TestingState = Default::default();
+
+    // basic test
+    let base_uri = array!['https://api.starknet.id/uri?id='];
+    uri_component.set_base_uri(base_uri.span());
+    let uri = uri_component.get_uri(12345);
+    assert(uri == array!['https://api.starknet.id/uri?id=', '12345'], 'wrong output uri');
+
+    // low/high test
+    let base_uri = array!['https://api.starknet.id/uri?id='];
+    uri_component.set_base_uri(base_uri.span());
+    let uri = uri_component.get_uri(3331111111111111111);
+    assert(
+        uri == array!['https://api.starknet.id/uri?id=', '3331111111111111111'],
+        'wrong output uri 2'
+    );
+
+    // 31 chars test
+    let base_uri = array!['https://api.starknet.id/uri?id='];
+    uri_component.set_base_uri(base_uri.span());
+    let uri = uri_component.get_uri(1000000000000000000000000000000);
+    assert(
+        uri == array!['https://api.starknet.id/uri?id=', '1000000000000000000000000000000'],
+        'wrong output uri 3'
+    );
+    // 31+ chars test
+    let base_uri = array!['https://api.starknet.id/uri?id='];
+    uri_component.set_base_uri(base_uri.span());
+    let uri = uri_component.get_uri(1000000000000000000000000000000234);
+    assert(
+        uri == array!['https://api.starknet.id/uri?id=', '1000000000000000000000000000000', '234'],
+        'wrong output uri'
+    );
+}
+
+
+#[test]
+#[available_gas(8000000)]
+fn test_appending_chars() {
+    // not many digits to add
+    let mut output = Default::default();
+    append_to_str(ref output, 'abcd', array!['e', 'f', 'g'].span());
+    assert(output == array!['abcdefg'], 'wrong string sum');
+
+    // 31 initially
+    let mut output = Default::default();
+    append_to_str(ref output, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', array!['e', 'f', 'g'].span());
+    assert(output == array!['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'efg'], 'wrong string sum');
+
+    // more than 31 to add
+    let mut output = Default::default();
+    append_to_str(ref output, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', array!['e', 'f', 'g'].span());
+    assert(output == array!['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaae', 'fg'], 'wrong string sum');
+
+    // adding 31 b
+    let mut output = Default::default();
+    append_to_str(
+        ref output,
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        array![
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+        ]
+            .span()
+    );
+    assert(
+        output == array!['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'],
+        'wrong string sum aza'
+    );
+
+    // adding 32 b
+    let mut output = Default::default();
+    append_to_str(
+        ref output,
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        array![
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b',
+            'b'
+        ]
+            .span()
+    );
+    assert(
+        output == array!['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'b'],
+        'wrong string sum'
+    );
 }

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -80,6 +80,7 @@ fn test_appending_id() {
         uri == array!['https://api.starknet.id/uri?id=', '1000000000000000000000000000000'],
         'wrong output uri 3'
     );
+
     // 31+ chars test
     let base_uri = array!['https://api.starknet.id/uri?id='];
     uri_component.set_base_uri(base_uri.span());
@@ -87,6 +88,15 @@ fn test_appending_id() {
     assert(
         uri == array!['https://api.starknet.id/uri?id=', '1000000000000000000000000000000', '234'],
         'wrong output uri'
+    );
+
+    // not 31 char basis
+    let base_uri = array!['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'];
+    uri_component.set_base_uri(base_uri.span());
+    let uri = uri_component.get_uri(123);
+    assert(
+        uri == array!['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb1', '23'],
+        'wrong output uri 4'
     );
 }
 

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -210,3 +210,13 @@ fn test_appending_chars() {
         'wrong string sum'
     );
 }
+
+#[test]
+#[available_gas(1500000)]
+fn test_custom_uri() {
+    let mut uri_component: TestingState = Default::default();
+
+    uri_component.set_base_uri(array!['https://my_api?token_id='].span());
+    let uri = uri_component.get_uri(123456789);
+    assert(uri == array!['https://my_api?token_id=1234567', '89'], 'invalid URI');
+}


### PR DESCRIPTION
This pull request introduces the `custom_uri_component` which allows a smart contract to set a custom URI in the storage and retrieve it by passing an ID as a parameter. This component acts as a utility module for handling URIs in StarkNet contracts.

### Changes:

1. **Custom URI Component**: A new module `custom_uri_component` is added which provides functions to set, get and compute URIs.

    - `get_base_uri`: Fetches the base URI set in the component.
    
    - `get_uri`: Appends a passed `u256` value to the base URI.
    
    - `set_base_uri`: Sets the base URI in the storage.

2. **Helper Functions**: Two utility functions `div_rec` and `append_to_str` have been added.

    - `div_rec`: Helper function to perform division recursively.
    
    - `append_to_str`: Appends a span of characters to a given string.

3. **Test Cases**: Tests have been added to validate the functionality of the component.

    - `test_base_uri`: Validates the set and retrieval of base URI.
    
    - `test_appending_id`: Validates the correct appending of IDs to the base URI.
    
    - `test_appending_chars`: Validates the proper appending of characters to strings.
